### PR TITLE
call api which creates chat room

### DIFF
--- a/ui/src/feature/api/chat.ts
+++ b/ui/src/feature/api/chat.ts
@@ -1,10 +1,14 @@
 import { API } from 'aws-amplify';
 import {
+  CreateRelayChatRoomTeamMutation,
   ChatMessagesByChatRoomIdQuery,
   RelayChatRoomTeamsByTeamIdQuery,
   CreateChatMessageMutation,
 } from '../../API';
-import { createChatMessage } from '../../graphql/mutations';
+import {
+  createRelayChatRoomTeam,
+  createChatMessage,
+} from '../../graphql/mutations';
 import {
   chatMessagesByChatRoomId,
   relayChatRoomTeamsByTeamId,
@@ -47,6 +51,22 @@ export const pushChatMessage = async (
         writeDateTime: new Date().getTime(),
         teamId,
         message,
+      },
+    },
+  });
+};
+
+export const createRelayChatRoom = async (
+  chatRoomId: string,
+  teamId: string
+) => {
+  await API.graphql<CreateRelayChatRoomTeamMutation>({
+    query: createRelayChatRoomTeam,
+    variables: {
+      input: {
+        chatRoomId,
+        writeDateTime: new Date().getTime(),
+        teamId,
       },
     },
   });


### PR DESCRIPTION
# やったこと
チャットルームを作成するAPIの呼び出し処理を実装しました。

# 動作確認
今回実装した処理をコンポーネントから呼び出し、以下が実現できることを確認しています。
- AWS上のDynamoDBにチャットルームが作成できる。
- 作成したチャットルームに対してメッセージを追加できる。
- 作成したチャットルームに追加したメッセージをメッセージ取得APIによって取得できる。
