### PR TITLE
Fix signOut

### DIFF
--- a/frontend/src/components/PrivateRoute.tsx
+++ b/frontend/src/components/PrivateRoute.tsx
@@ -8,6 +8,6 @@ interface Props {
 
 // ログイン後に表示する画面に使用する。
 export const PrivateRoute: React.FC<Props> = ({ children }) => {
-  const isAuthenticated = useAuth();
-  return isAuthenticated ? <div>{children}</div> : <Navigate to="/" />;
+  const auth = useAuth();
+  return auth.isAuthenticated ? <div>{children}</div> : <Navigate to="/" />;
 };

--- a/frontend/src/hooks/signOut/useSignOut.ts
+++ b/frontend/src/hooks/signOut/useSignOut.ts
@@ -1,0 +1,23 @@
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../auth/useAuth';
+
+export const useSignOut = () => {
+  const auth = useAuth();
+  const navigate = useNavigate();
+
+  /** サインアウト処理を呼び出す */
+  const executeSignOut = () => {
+    auth
+      .signOut()
+      .then(() => {
+        navigate({ pathname: '/' });
+      })
+      .catch((error) => {
+        console.log(error); // eslint-disable-line no-console
+      });
+  };
+
+  return {
+    executeSignOut,
+  };
+};

--- a/frontend/src/pages/top/Top.tsx
+++ b/frontend/src/pages/top/Top.tsx
@@ -4,13 +4,11 @@ import axios from 'axios';
 import { PrivateRoute } from '../../components/PrivateRoute';
 import { backendUrl } from '../../config';
 import { useAuth } from '../../hooks/auth/useAuth';
+import { useSignOut } from '../../hooks/signOut/useSignOut';
 
 export const TopBackup: React.FC = () => {
   const auth = useAuth();
-
-  if (auth.isLoading) {
-    return <div />;
-  }
+  const { executeSignOut } = useSignOut();
 
   useEffect(() => {
     axios
@@ -23,6 +21,10 @@ export const TopBackup: React.FC = () => {
       });
   }, []);
 
+  if (auth.isLoading) {
+    return <div />;
+  }
+
   return (
     <PrivateRoute>
       <div>email: {auth.email}</div>
@@ -30,11 +32,9 @@ export const TopBackup: React.FC = () => {
         <Link to="/chat">チャット画面に遷移</Link>
       </div>
       <div>
-        <Link to="/">
-          <button type="button" onClick={() => auth.signOut}>
-            ログアウト
-          </button>
-        </Link>
+        <button type="submit" onClick={() => executeSignOut()}>
+          ログアウト
+        </button>
       </div>
     </PrivateRoute>
   );


### PR DESCRIPTION
## サインアウトされなかった原因
ログアウトボタンを押下したときに呼び出す関数のカッコをつけ忘れていた。
カッコをつけないと関数の参照のみで実行はされないらしい。
https://zenn.dev/arei/scraps/3e5ad57807fb67

## やったこと
- サインアウト処理の修正
  - ログアウト処理で呼び出す関数にカッコをつける
  - ただonClickイベント処理に渡す関数の戻り値はvoidにする必要があり、signOut()の戻り値はPromise<void>のためエラーとなる
  - そのためsignOutの処理を待ってから戻り値を返すラッパー関数を用意（executeSignOut）
- 認証済みのコンポーネントを表示するPrivateRouteが機能していなかったので、修正
  - authで条件分岐しているところを、auth.isAuthenticatedに修正

